### PR TITLE
Add github action to do a test build of this theory on each push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,10 @@
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Theory
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lexbailey/isabelle-theory-build-github-action@v4
+        with:
+          isabelle-version: '2021-1'


### PR DESCRIPTION
@simondfoster this is the first of the pull requests for getting automated builds running on all the isabelle-utp modules.

Currently I can only put in pull requests for three modules: Optics, Total_Recall, and explore-subgoal, since these have no dependencies.

The other modules depend on these ones (directly or indirectly) so I have to do this in stages, updating the dependencies after each PR is merged since these files are read by the dependency resolution code, so they need to be in the dependency repo before the build will pass in the dependent repo.

I'll have to do this in 5 batches, these three PRs being the first batch, and most of the other batches being individual repos. It's a bit frustrating, but this way ensures that we can actually check each build works before merging this change.